### PR TITLE
readme: Fix repository reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For `lsp-ltex-plus` to work, Emacs must be able to find the `ltex-ls-plus` binar
 
 ```elisp
 (straight-use-package
- '(lsp-ltex-plus :type git :host github :repo "username/emacs-ltex-plus"))
+ '(lsp-ltex-plus :type git :host github :repo "alberti42/emacs-ltex-plus"))
 ```
 
 ### Manual Installation


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Correct the GitHub repository URL in the README installation snippet for lsp-ltex-plus.